### PR TITLE
Update how to install it

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ To do list
 - [x] Decrypt data
 - [x] Change state
 
-# How to install it (Linux)
+# How to install it
 1. Make venv: `python3 -m venv venv`
-2. Activate venv: `source venv/bin/activate`
-3. Install wheel: `pip install wheel`
-4. Install requirements `pip install -r req.txt`
 
-# How to install it (Windows)
-TODO
+2. Activate venv: 
+    * Linux: `source venv/bin/activate`
+    * Windows: `./venv/Scripts/activate`
+
+3. Install requirements `pip install -r req.txt`
 
 # How to use it
 ```

--- a/req.txt
+++ b/req.txt
@@ -3,7 +3,7 @@ chardet==3.0.4
 idna==2.10
 jsons==1.3.0
 pkcs7==0.1.2
-pycryptodome==3.9.8
+pycryptodome==3.18.0
 requests==2.24.0
 typish==1.9.1
 urllib3==1.25.10


### PR DESCRIPTION
Add the windows command to activate venv

I didn't see in any code that wheel was required, and it functioned perfectly without it, so I removed it. 
Please correct me if necessary!

Upgrade the pycryptodome requirement cause it caused an metadata-generation-failed error
3.9.8 -> 3.18.0